### PR TITLE
feat: Added darconLog to logger instance when missing.

### DIFF
--- a/Darconer.js
+++ b/Darconer.js
@@ -12,6 +12,8 @@ const fs = require('fs')
 const path = require('path')
 let VERSION = exports.VERSION = JSON.parse( fs.readFileSync( path.join( __dirname, 'package.json'), 'utf8' ) ).version
 
+const { ensureDarconLog } = require('./util/Logger')
+
 let { MODE_REQUEST, MODE_INFORM, MODE_DELEGATE, newPacket, newPresencer, newConfig } = require( './Models' )
 
 let { BaseErrors, ErrorCreator } = require( './util/Errors' )
@@ -69,6 +71,8 @@ Object.assign( Darcon.prototype, {
 	async init (config = {}) { let self = this
 		this.name = config.name || 'Daconer'
 		config.logger = config.logger || PinoLogger( this.name, { level: this.logLevel, prettyPrint: process.env.DARCON_LOG_PRETTY || false } )
+
+		config.logger = ensureDarconLog(config.logger)
 
 		config = await newConfig( config )
 		assigner.assign( self, config )

--- a/util/Logger.js
+++ b/util/Logger.js
@@ -1,0 +1,13 @@
+function ensureDarconLog(loggerInstance) {
+	if(typeof loggerInstance.darconlog !== 'undefined') return loggerInstance
+	loggerInstance.darconlog = function ( err, message, obj, level ) {
+		if (err)
+			this[ 'error' ]( err, err.message || err.toString() )
+		else
+			this[ level || 'debug' ]( obj || { }, message )
+	}.bind( loggerInstance )
+	return loggerInstance
+}
+module.exports = {
+	ensureDarconLog
+}


### PR DESCRIPTION
If someone pass a loggerInstance without darconLogger function, the service will throw an error. We should ensure, that the passed loggerInstance is compatible with Darcon.